### PR TITLE
Harden tests to deal with "Stop on first syntax error" patch in 5.37.4

### DIFF
--- a/Code.xs
+++ b/Code.xs
@@ -259,6 +259,7 @@ static OP *parse_qctail(pTHX_ const QCSpec *spec, int *pnesting) {
             switch (c) {
                 case -1:
                     missing_terminator(aTHX_ spec, start);
+                    break;
 
                 case 'a': c = '\a'; break;
                 case 'b': c = '\b'; break;

--- a/t/02-unload.t
+++ b/t/02-unload.t
@@ -6,7 +6,7 @@ use Test::More tests => 9;
 use Quote::Code ();
 
 is eval('qc]1]'), undef;
-like $@, qr/Number found where operator/;
+like $@, qr/syntax error/;
 
 {
     use Quote::Code;
@@ -14,7 +14,7 @@ like $@, qr/Number found where operator/;
 }
 
 is eval('qc]1]'), undef;
-like $@, qr/Number found where operator/;
+like $@, qr/syntax error/;
 
 use Quote::Code;
 is qc]1], '1';
@@ -22,7 +22,7 @@ is qc]1], '1';
 {
     no Quote::Code;
     is eval('qc]1]'), undef;
-    like $@, qr/Number found where operator/;
+    like $@, qr/syntax error/;
 }
 
 is qc]1], '1';


### PR DESCRIPTION
See also: https://github.com/Perl/perl5/issues/20346